### PR TITLE
Fix orientation and mirroring for recorded video

### DIFF
--- a/CameraSwitchApp/CameraViewController.swift
+++ b/CameraSwitchApp/CameraViewController.swift
@@ -192,7 +192,25 @@ class CameraViewController: UIViewController {
             }
         }
     }
-    
+
+    private func currentVideoTransform() -> CGAffineTransform {
+        var transform = CGAffineTransform.identity
+        switch UIDevice.current.orientation {
+        case .landscapeRight:
+            transform = CGAffineTransform(rotationAngle: .pi / 2)
+        case .landscapeLeft:
+            transform = CGAffineTransform(rotationAngle: -.pi / 2)
+        case .portraitUpsideDown:
+            transform = CGAffineTransform(rotationAngle: .pi)
+        default:
+            transform = .identity
+        }
+        if videoInput?.device.position == .front {
+            transform = transform.scaledBy(x: -1, y: 1)
+        }
+        return transform
+    }
+
     // MARK: - Writer Control
     private func startWritingSession() {
         let outputURL = FileManager.default.temporaryDirectory
@@ -212,6 +230,8 @@ class CameraViewController: UIViewController {
         }
         let vInput = AVAssetWriterInput(mediaType: .video, outputSettings: vSettings)
         vInput.expectsMediaDataInRealTime = true
+        // Ensure recorded video matches current orientation and mirroring
+        vInput.transform = currentVideoTransform()
         pixelBufferAdaptor = AVAssetWriterInputPixelBufferAdaptor(
             assetWriterInput: vInput,
             sourcePixelBufferAttributes: nil


### PR DESCRIPTION
## Summary
- ensure recorded videos honor device orientation and front camera mirroring

## Testing
- `xcodebuild -version` (fails: command not found)
- `swiftc CameraSwitchApp/CameraViewController.swift` (fails: no such module 'UIKit')

------
https://chatgpt.com/codex/tasks/task_e_68a8169cfab883239487b6613e3a123b