### PR TITLE
Replace photo library usage key

### DIFF
--- a/CameraSwitchApp/Info.plist
+++ b/CameraSwitchApp/Info.plist
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>App needs to save your recorded videos into your Photo Library so you can view them later.</string>
+        <key>NSPhotoLibraryAddUsageDescription</key>
+        <string>App requires permission to add your recorded videos to your Photo Library so you can view them later.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>App requires microphone access to record audio.</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
## Summary
- replace deprecated `NSPhotoLibraryUsageDescription` with `NSPhotoLibraryAddUsageDescription`
- explain need to add recorded videos to the user's photo library

## Testing
- `plutil -lint CameraSwitchApp/Info.plist` *(fails: command not found)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a81add31b483238c0eaa7454d467c3